### PR TITLE
Overrode the delete_all method on Webhooks.

### DIFF
--- a/bigcommerce/resources/webhooks.py
+++ b/bigcommerce/resources/webhooks.py
@@ -4,3 +4,7 @@ from .base import *
 class Webhooks(ListableApiResource, CreateableApiResource,
                UpdateableApiResource, DeleteableApiResource):
     resource_name = 'hooks'
+
+    @classmethod
+    def delete_all(self, connection=None):
+        raise NotImplementedError("The webhook resource does not have delete_all endpoint")

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -1,6 +1,7 @@
 import unittest
 from bigcommerce.resources import Mapping, Orders, ApiResource, OrderShipments
 from bigcommerce.resources.orders import OrderCoupons
+from bigcommerce.resources.webhooks import Webhooks
 from mock import MagicMock
 
 
@@ -168,3 +169,9 @@ class TestDeleteableApiSubResource(unittest.TestCase):
         self.assertEqual(shipment.delete(), {})
 
         connection.make_request.assert_called_once_with('DELETE', 'orders/2/shipments/1', None, {}, {})
+
+    def test_webhook_delete_all(self):
+        connection = MagicMock()
+        connection.make_request.return_value = {}
+
+        self.assertRaises(NotImplementedError, Webhooks.delete_all, connection=connection)


### PR DESCRIPTION
Since not having a delete_all endpoint on the webhook resource is exceptional, I think it is better to treat it exceptionally and raise a `NotImplementedError`.
